### PR TITLE
RemoteServerManager.GetServerGroup() method doesn't exist

### DIFF
--- a/advanced/clustering/server_clustering_api_overview.md
+++ b/advanced/clustering/server_clustering_api_overview.md
@@ -11,7 +11,7 @@ The following code is written from the perspective of a plugin.
 ### Accessing Servers
 In most cases you will access servers by knowing what group they're in.
 ```c#
-IServerGroup serverGroup = RemoteServerManager.GetServerGroup(groupName);
+IServerGroup serverGroup = RemoteServerManager.GetGroup(groupName);
 IRemoteServer[] remoteServers = serverGroup.GetAllRemoteServers();
 ```
 


### PR DESCRIPTION
RemoteServerManager.GetServerGroup() method seems to be obsolete. There is only a GetGroup() method.