### PR TITLE
github action for pages deploy

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -2,7 +2,8 @@
 #
 
 name: Pages
-on: [push]
+on:
+  workflow_dispatch:
 jobs:
   publish-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -7,7 +7,7 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Chekout
+      - name: Checkout
         uses: actions/checkout@v3
       - name: Dotnet Setup
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,6 +1,3 @@
-# Your GitHub workflow file under .github/workflows/
-#
-
 name: Pages
 on:
   workflow_dispatch:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,23 @@
+# Your GitHub workflow file under .github/workflows/
+#
+
+name: Pages
+on: [push]
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Chekout
+        uses: actions/checkout@v3
+      - name: Dotnet Setup
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x
+      - name: build
+        uses: mattnotmitt/doxygen-action@v1.9.5
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _docs/html


### PR DESCRIPTION
adding workflow to build the pages and publish

couple of settings required  shown below

give the token access to publish to the repo and once its made a branch select the gh-pages branch as the deploy branch in the pages setting


![](https://cdn.discordapp.com/attachments/1079323624818880543/1122235328212770826/image.png)

![](https://cdn.discordapp.com/attachments/1079323624818880543/1122236174497497160/image.png)
